### PR TITLE
Fix tar (internal method) with "files" argument

### DIFF
--- a/R/tar.R
+++ b/R/tar.R
@@ -380,8 +380,10 @@ tar <- function(tarfile, files = NULL,
 ### ----- from here on, using internal code -----
         ## must do this before tarfile is created
         if(is.null(files)) files <- "."
-        files <- list.files(files, recursive = TRUE, all.files = TRUE,
-                            full.names = TRUE, include.dirs = TRUE)
+        descend <- files[file.info(files)$isdir]
+        files <- union(files,
+                       list.files(descend, recursive = TRUE, all.files = TRUE,
+                                  full.names = TRUE, include.dirs = TRUE))
 
         con <- switch(match.arg(compression),
                       "none" =  file(tarfile, "wb"),


### PR DESCRIPTION
tar ignores all "files" arguments that are not directories using "internal" method

This is the same bug as here: https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=16716 and appears to be still present in R.

## The problem

```r
tmp <- tempfile()
dir.create(tmp)
owd <- setwd(tmp)
for (i in letters) {
  writeLines(i, i)
}
```

Works fine with system tar:

```
tar::tar("some.tar", letters[1:6], tar = Sys.which("tar"))
untar("some.tar", list = TRUE)
## [1] "a" "b" "c" "d" "e" "f"
```

Broken with internal tar:

```
tar::tar("some.tar", letters[1:6])
untar("some.tar", list = TRUE)
## character(0)
```

```
setwd(owd)
```
